### PR TITLE
ascend: align attention mask to 32bytes

### DIFF
--- a/lmdeploy/pytorch/engine/devices/ascend.py
+++ b/lmdeploy/pytorch/engine/devices/ascend.py
@@ -17,7 +17,7 @@ class ASCENDDeviceUtils(DIPUDeviceUtils):
             single_attention_mask = torch.logical_not(
                 torch.tril(
                     torch.ones(step_context.q_seq_length[i],
-                               step_context.kv_seq_length[i],
+                               (step_context.kv_seq_length[i] + 31) // 32 * 32,
                                dtype=torch.bool).cuda(),
                     diagonal=step_context.kv_seq_length[i] -
                     step_context.q_seq_length[i],

--- a/lmdeploy/pytorch/engine/devices/ascend.py
+++ b/lmdeploy/pytorch/engine/devices/ascend.py
@@ -17,7 +17,7 @@ class ASCENDDeviceUtils(DIPUDeviceUtils):
             single_attention_mask = torch.logical_not(
                 torch.tril(
                     torch.ones(step_context.q_seq_length[i],
-                               (step_context.kv_seq_length[i] + 31) // 32 * 32,
+                               (step_context.kv_seq_length[i] + 31) & (~31),
                                dtype=torch.bool).cuda(),
                     diagonal=step_context.kv_seq_length[i] -
                     step_context.q_seq_length[i],


### PR DESCRIPTION

![img_v3_02dt_c1ca3d12-9512-43af-a6b8-8173cf60c8ag](https://github.com/user-attachments/assets/571499ee-fbde-4288-b111-a03d4b6fa203)
[CANN](https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/80RC3alpha001/apiref/appdevgapi/context/aclnnIncreFlashAttentionV4.md?sub_id=%2Fzh%2FCANNCommunityEdition%2F80RC3alpha001%2Fapiref%2Fappdevgapi%2Fcontext%2FaclnnPromptFlashAttention.md)建议attention mask对齐到32字节以保证性能。
![img_v3_02dt_f10cdb5f-93de-4812-b4a9-1bba6d4f187g](https://github.com/user-attachments/assets/7abd0d14-3dad-4485-a2e4-7057d800ada3)
如上脚本运行，如果attention mask没有对齐到32bytes则会报错，对齐到32bytes则通过
![img_v3_02dt_c2df01aa-6d6f-4792-af53-11fef343ba8g](https://github.com/user-attachments/assets/32720239-eadc-4742-b62b-c5406ab1b219)
![img_v3_02dt_c825b87c-3463-4171-b3d6-74416c46719g](https://github.com/user-attachments/assets/9af35b77-c7a8-407e-a89b-2f3e7424c559)

